### PR TITLE
Adds a static source component for storybook

### DIFF
--- a/.storybook/components/static-source.jsx
+++ b/.storybook/components/static-source.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import { Source } from '@storybook/addon-docs/blocks';
+
+const StaticSource = ({code}) => (
+    <Source
+        language='html'
+        code={ReactDOMServer.renderToStaticMarkup(code)}
+    />
+);
+
+export default StaticSource;


### PR DESCRIPTION
Merges into our add-elements branch for #9 for further merging into the main branch.

This component takes a react element into the `code` prop and it will render it out into a static html source block for use within MDX and our docs.

Helps with #5 