### PR TITLE
Ability to pass through tags to replace <a>

### DIFF
--- a/lib/elements/back/index.jsx
+++ b/lib/elements/back/index.jsx
@@ -5,7 +5,7 @@ export const Back = (props) => {
     const { href, tag: Tag, text, ...attributes } = props;
 
     return (
-        <Tag href={href} className="link-back" {...attributes}>
+        <Tag href={href} className="link-back" to={href} {...attributes}>
             {text}
         </Tag>
     );

--- a/lib/elements/back/index.jsx
+++ b/lib/elements/back/index.jsx
@@ -1,17 +1,24 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-export const Back = ({ href, text }) => {
+export const Back = (props) => {
+    const { href, tag: Tag, text, ...attributes } = props;
+
     return (
-        <a href={href} className="link-back">
+        <Tag href={href} className="link-back" {...attributes}>
             {text}
-        </a>
+        </Tag>
     );
 };
 
 Back.propTypes = {
     href: PropTypes.string.isRequired,
+    tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
     text: PropTypes.string.isRequired,
+};
+
+Back.defaultProps = {
+    tag: "a",
 };
 
 export default Back;

--- a/lib/elements/button/index.jsx
+++ b/lib/elements/button/index.jsx
@@ -2,35 +2,37 @@ import React from "react";
 import PropTypes from "prop-types";
 
 export const Button = (props) => {
-    if (props.type === "submit") {
-        return (
-            <input type="submit" className="button" value={props.children} />
-        );
+    const { children, href, tag: Tag, type } = props;
+
+    if (type === "submit") {
+        return <input type="submit" className="button" value={children} />;
     }
 
-    if (props.type === "text") {
+    if (type === "text") {
         return (
             <button className="text" type="button">
-                {props.children}
+                {children}
             </button>
         );
     }
 
     return (
-        <a className="button button-start" href={props.href} role="button">
-            {props.children}
-        </a>
+        <Tag className="button button-start" href={href} role="button">
+            {children}
+        </Tag>
     );
 };
 
 Button.propTypes = {
     children: PropTypes.node.isRequired,
     href: PropTypes.string,
+    tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
     type: PropTypes.oneOf(["button", "text", "submit"]),
 };
 
 Button.defaultProps = {
     href: "",
+    tag: "a",
     type: "button",
 };
 

--- a/lib/elements/button/index.jsx
+++ b/lib/elements/button/index.jsx
@@ -17,7 +17,12 @@ export const Button = (props) => {
     }
 
     return (
-        <Tag className="button button-start" href={href} role="button">
+        <Tag
+            className="button button-start"
+            href={href}
+            role="button"
+            to={href}
+        >
             {children}
         </Tag>
     );

--- a/lib/elements/link/index.jsx
+++ b/lib/elements/link/index.jsx
@@ -1,7 +1,15 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-export const Link = ({ children, download, external, href, target, title }) => {
+export const Link = ({
+    children,
+    download,
+    external,
+    href,
+    tag: Tag,
+    target,
+    title,
+}) => {
     if (external) {
         let infoMsg = "Replacing your browser tab with an external website";
 
@@ -28,9 +36,9 @@ export const Link = ({ children, download, external, href, target, title }) => {
     }
 
     return (
-        <a href={href} title={title}>
+        <Tag href={href} title={title}>
             {children}
-        </a>
+        </Tag>
     );
 };
 
@@ -39,6 +47,7 @@ Link.propTypes = {
     download: PropTypes.bool,
     external: PropTypes.bool,
     href: PropTypes.string.isRequired,
+    tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
     target: PropTypes.oneOf(["", "_blank"]),
     title: PropTypes.string.isRequired,
 };
@@ -46,6 +55,7 @@ Link.propTypes = {
 Link.defaultProps = {
     download: false,
     external: false,
+    tag: "a",
     target: "",
 };
 

--- a/lib/elements/link/index.jsx
+++ b/lib/elements/link/index.jsx
@@ -36,7 +36,7 @@ export const Link = ({
     }
 
     return (
-        <Tag href={href} title={title}>
+        <Tag href={href} to={href} title={title}>
             {children}
         </Tag>
     );


### PR DESCRIPTION
As we're working on a mix of Gatsby and normal sites, it's worth while using Gatsby's Link tag over a standard `<a>`. This change allows certain components to accept a `tag` prop which will replace the `<a>` with whatever component was passed through.

For example: 
```jsx
import React from "react";
import { Link } from "gatsby";
import { Button } from '@essexcountycouncil/components-library';
<Button href={`/${nextLink}`} tag={Link}>Next</Button>
```

If you don't pass this tag prop through it will default to the `<a>`