### PR TITLE
Adds an emergency banner component

### DIFF
--- a/lib/components/emergency-banner/index.jsx
+++ b/lib/components/emergency-banner/index.jsx
@@ -1,0 +1,64 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+// Via https://raw.githubusercontent.com/alphagov/static/main/app/views/components/_emergency_banner.html.erb with some modifications
+/**
+ * EmergencyBanner
+ *
+ * @param {String} type The type of banner to display
+ * @param {String} heading Banner Heading
+ * @param {String} content Banner Content
+ * @param {Object} link An object containing a href, title and text for the link
+ * @returns {Component} EmergencyBanner
+ */
+export const EmergencyBanner = ({ type, heading, content, link }) => (
+    <div
+        className={`emergency-banner emergency-banner--${type}`}
+        role="banner"
+        data-nosnippet
+    >
+        <div className="container">
+            <section className="content">
+                <div className="column-two-thirds">
+                    <h2 className="emergency-banner__heading">{heading}</h2>
+                    {content && (
+                        <p className="emergency-banner__description">
+                            {content}
+                        </p>
+                    )}
+                    {link.url && (
+                        <a
+                            href={link.url}
+                            className="emergency-banner__link govuk-link"
+                            title={link.title}
+                        >
+                            {link.text}
+                        </a>
+                    )}
+                </div>
+            </section>
+        </div>
+    </div>
+);
+
+EmergencyBanner.propTypes = {
+    type: PropTypes.oneOf([
+        "notable-death",
+        "national-emergency",
+        "local-emergency",
+    ]).isRequired,
+    heading: PropTypes.string.isRequired,
+    content: PropTypes.string,
+    link: PropTypes.shape({
+        url: PropTypes.string.isRequired,
+        text: PropTypes.string.isRequired,
+        title: PropTypes.string,
+    }),
+};
+
+EmergencyBanner.defaultProps = {
+    content: "",
+    link: null,
+};
+
+export default EmergencyBanner;

--- a/lib/components/emergency-banner/index.stories.mdx
+++ b/lib/components/emergency-banner/index.stories.mdx
@@ -1,0 +1,85 @@
+import { Meta, Story, Canvas, ArgsTable, Source } from "@storybook/addon-docs/blocks";
+import StaticSource from '../../../.storybook/components/static-source.jsx';
+import { EmergencyBanner } from "./index.jsx";
+
+export const defaultArgs = {
+    type: "notable-death",
+    heading: "His Royal Highness Henry VIII",
+    content: "1509-1547",
+    link: {url: 'https://en.wikipedia.org/wiki/Henry_VIII', text: 'More information', title: 'Henry VIII'}
+};
+
+<Meta
+    title="Components/Emergency Banner"
+    component={EmergencyBanner}
+    argTypes={{
+        type: {
+            name: "Type",
+            description: "Type of banner to show",
+            control: {
+                type: "select",
+                options: ['notable-death', 'national-emergency', 'local-emergency'],
+            },
+        },
+        heading: {
+            name: "Banner heading",
+            description: "Heading",
+        },
+        content: {
+            name: "Content",
+            description: "Text",
+        },
+    }}
+    parameters={{
+        actions: {
+            disable: true,
+        },
+    }}
+/>
+
+# Emergency Banner
+
+<ArgsTable of={EmergencyBanner} />
+
+### General
+
+<Story
+    name="Emergency Banner"
+    args={defaultArgs}
+>
+    {(args) => (
+        <EmergencyBanner {...args} />
+    )}
+</Story>
+
+<Source
+    code={`
+<EmergencyBanner
+    type="notable-death"
+    heading="His Royal Highness Henry VIII"
+    content="1509-1547"
+    link={{
+        url: 'https://en.wikipedia.org/wiki/Henry_VIII',
+        text: 'More information',
+        title: 'Henry VIII'
+    }}
+/>
+`}
+/>
+
+<StaticSource
+    code={EmergencyBanner(defaultArgs)}
+/>
+
+### Homepage only
+
+<Story
+    name="Emergency Banner on Homepage"
+    args={defaultArgs}
+>
+    {(args) => (
+        <div className="homepage">
+            <EmergencyBanner {...args} />
+        </div>
+    )}
+</Story>

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-unresolved */ //Just for the moment
 export { Alert } from "./components/alert";
 export { BrowserCheck } from "./components/browser-check";
+export { EmergencyBanner } from "./components/emergency-banner";
 export { Footer } from "./components/footer";
 export { Header } from "./components/header";
 export { HighlightBox } from "./components/highlight-box";

--- a/lib/scss/core/components/_emergency-banner.scss
+++ b/lib/scss/core/components/_emergency-banner.scss
@@ -1,0 +1,104 @@
+// Via https://raw.githubusercontent.com/alphagov/static/main/app/assets/stylesheets/components/_emergency-banner.scss 19/7/21 with some modifications
+
+.emergency-banner {
+    font-size: 19px !important;
+    font-size: 1.1875rem !important;
+    line-height: 1.31579 !important;
+
+    background-color: $grey;
+    color: $white;
+    margin-top: 2px;
+    padding: 15px 0;
+
+    @include media(tablet) {
+        padding: 30px 0;
+    }
+
+    .homepage & {
+        border-bottom: 5px solid $white;
+        border-top: 5px solid $white;
+        margin-bottom: (0 - 10px);
+        margin-top: 0;
+        position: relative;
+        z-index: 10;
+    }
+}
+
+.emergency-banner .container {
+    @extend %site-width-container;
+    @extend %contain-floats;
+}
+
+.emergency-banner .container .content {
+    @extend %grid-row;
+}
+
+.emergency-banner .container .content .column-two-thirds {
+    @include grid-column(2 / 3);
+}
+
+.emergency-banner__heading {
+    font-size: 24px !important;
+    font-size: 1.5rem !important;
+    line-height: 1.25 !important;
+    font-weight: bold;
+
+    margin: 0;
+
+    .homepage & {
+        font-size: 48px !important;
+        font-size: 3rem !important;
+        line-height: 1.04167 !important;
+        font-weight: bold;
+
+        @include media(tablet) {
+            margin-bottom: 20px;
+        }
+    }
+}
+
+.emergency-banner__description {
+    font-size: 19px !important;
+    font-size: 1.1875rem !important;
+    line-height: 1.31579 !important;
+
+    color: $white;
+    margin-top: 0;
+    margin-bottom: 20px;
+
+    &:last-child {
+        margin-bottom: 0;
+    }
+
+    .homepage & {
+        margin: 20px 0;
+    }
+}
+
+.emergency-banner__link {
+    font-size: 19px !important;
+    font-size: 1.1875rem !important;
+    line-height: 1.31579 !important;
+
+    &.govuk-link:link,
+    &.govuk-link:visited {
+        color: $white;
+    }
+
+    &.govuk-link:focus {
+        color: $focus-colour;
+    }
+}
+
+.emergency-banner--notable-death {
+    background-color: $grey-darker;
+}
+
+.emergency-banner--national-emergency {
+    // Not using govuk-colour("red") aka #d4351c as that's a slightly different red.
+    background-color: #b10e1e;
+}
+
+.emergency-banner--local-emergency {
+    background-color: #28a197;
+}

--- a/lib/scss/core/components/_header.scss
+++ b/lib/scss/core/components/_header.scss
@@ -1,40 +1,40 @@
 .header-background {
-  background-color: $brand;
-  border-bottom: $border-thin solid $brand4;
-  height: auto;
-  position: relative;
-  z-index: 20;
-  @media print {
-    background-color: $white;
+    background-color: $brand;
+    border-bottom: $border-thin solid $brand4;
     height: auto;
-    @include box-shadow(none);
-  }
-  .header {
-    @extend %site-width-container;
-    @extend %contain-floats;
+    position: relative;
+    z-index: 20;
     @media print {
-      margin: 0;
+        background-color: $white;
+        height: auto;
+        @include box-shadow(none);
     }
-    .nav {
-    @extend %grid-row;
-      .logo-wrap {
-        height: $form-height*0.75;
-        @include grid-column(1 / 2);
-        a.logo-text {
-          @media print {
-            color: $black;
-            font-size: $small;
-          }
-        }
-      }
-      span {
-        @include small;
-        font-size: 0.5em;
-        color: $white;
+    .header {
+        @extend %site-width-container;
+        @extend %contain-floats;
         @media print {
-          color: $black;
+            margin: 0;
         }
-      }
+        .nav {
+            @extend %grid-row;
+            .logo-wrap {
+                height: $form-height * 0.75;
+                @include grid-column(1 / 2);
+                a.logo-text {
+                    @media print {
+                        color: $black;
+                        font-size: $small;
+                    }
+                }
+            }
+            span {
+                @include small;
+                font-size: 0.5em;
+                color: $white;
+                @media print {
+                    color: $black;
+                }
+            }
+        }
     }
-  }
 }

--- a/lib/scss/core/components/_import.scss
+++ b/lib/scss/core/components/_import.scss
@@ -3,6 +3,7 @@
 @import "browser-check";
 @import "cookies";
 @import "contents";
+@import "emergency-banner";
 @import "file-download";
 @import "footer";
 @import "header";


### PR DESCRIPTION
Follows the govuk banner at https://docs.publishing.service.gov.uk/manual/emergency-publishing.html#gov-uk-homepage very closely. Bonus I kept the other options so if we do need to use it for a national emergency then it's all ready to go (hopefully)