### PR TITLE
Update emergency banner

### DIFF
--- a/lib/components/emergency-banner/index.jsx
+++ b/lib/components/emergency-banner/index.jsx
@@ -20,7 +20,12 @@ export const EmergencyBanner = ({ type, heading, content, link }) => (
         <div className="container">
             <section className="content">
                 <div className="column-two-thirds">
-                    <h2 className="emergency-banner__heading">{heading}</h2>
+                    <h2
+                        id="emergency__heading"
+                        className="emergency-banner__heading"
+                    >
+                        {heading}
+                    </h2>
                     {content && (
                         <p className="emergency-banner__description">
                             {content}
@@ -29,8 +34,9 @@ export const EmergencyBanner = ({ type, heading, content, link }) => (
                     {link.url && (
                         <a
                             href={link.url}
-                            className="emergency-banner__link govuk-link"
-                            title={link.title}
+                            className="emergency-banner__link"
+                            id="emergency__link"
+                            aria-labelledby="emergency__link emergency__heading"
                         >
                             {link.text}
                         </a>
@@ -52,7 +58,6 @@ EmergencyBanner.propTypes = {
     link: PropTypes.shape({
         url: PropTypes.string.isRequired,
         text: PropTypes.string.isRequired,
-        title: PropTypes.string,
     }),
 };
 

--- a/lib/components/emergency-banner/index.stories.mdx
+++ b/lib/components/emergency-banner/index.stories.mdx
@@ -6,7 +6,7 @@ export const defaultArgs = {
     type: "notable-death",
     heading: "His Royal Highness Henry VIII",
     content: "1509-1547",
-    link: {url: 'https://en.wikipedia.org/wiki/Henry_VIII', text: 'More information', title: 'Henry VIII'}
+    link: {url: 'https://en.wikipedia.org/wiki/Henry_VIII', text: 'More information'}
 };
 
 <Meta
@@ -60,8 +60,7 @@ export const defaultArgs = {
     content="1509-1547"
     link={{
         url: 'https://en.wikipedia.org/wiki/Henry_VIII',
-        text: 'More information',
-        title: 'Henry VIII'
+        text: 'More information'
     }}
 />
 `}

--- a/lib/scss/core/components/_emergency-banner.scss
+++ b/lib/scss/core/components/_emergency-banner.scss
@@ -80,13 +80,17 @@
     font-size: 1.1875rem !important;
     line-height: 1.31579 !important;
 
-    &.govuk-link:link,
-    &.govuk-link:visited {
+    &:link,
+    &:visited {
         color: $white;
     }
 
-    &.govuk-link:focus {
-        color: $focus-colour;
+    &:hover {
+        color: $grey-lighter;
+    }
+
+    &:focus {
+        color: $black;
     }
 }
 


### PR DESCRIPTION
- Fixes the focus psuedo styling by making the text colour inline with what we have on the Essex website.
- Removes the title attribute on the link in favour of using the `aria-labelledby` attribute for getting the context of the link.